### PR TITLE
(v 0.1.1) Change the interface a little bit and add a function `initial_condition`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyFym"
 uuid = "19ce2a37-d051-4e03-9a1e-989d2d09a817"
 authors = ["JinraeKim <kjl950403@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ using LinearAlgebra
 
 
 # systems
-struct Sys1 <: FymSys
+struct Sys1 <: FymEnv
     a
 end
-struct Sys2 <: FymSys
+struct Sys2 <: FymEnv
     b
 end
 # environments
@@ -49,18 +49,19 @@ struct Env <: FymEnv
 end
 # dynamics
 function ẋ(env::Env, x, t; c=1)
-    x1 = x[:sys1]
-    x2 = x[:sys2]
+    x1 = x.sys1  # x will be given as NamedTuple
+    x2 = x.sys2
     ẋ1 = -(env.sys1.a * c) * x1
     ẋ2 = -(env.sys2.b * c) * x2
-    return zip([:sys1, :sys2], [ẋ1, ẋ2]) |> Dict
+    return (; zip([:sys1, :sys2], [ẋ1, ẋ2])...)  # NamedTuple; Dict will also work
 end
 # update rule within each time step
 function update(env::Env, ẋ, x, t, Δt)
-    datum = Dict(:x1 => x[:sys1], :x2 => x[:sys2], :t => t)
+    _datum = Dict(:x1 => x.sys1, :x2 => x.sys2, :t => t)
     c = gain(t)
     x_next = ∫(env, ẋ, x, t, Δt; c=c)  # default method: RK4
-    # datum[:x_next] = x  # if necessary
+    _datum[:x_next] = x_next  # if necessary
+    datum = (; zip(keys(_datum), values(_datum))...)  # to make it immutable; not necessary
     return datum, x_next
 end
 function gain(t)
@@ -68,22 +69,19 @@ function gain(t)
 end
 # terminal condition
 function is_terminated(datum)
-    return datum[:t] > 50
+    return norm(datum.x1) < 1e-6
 end
-# trajs -> dict
+# trajs -> NamedTuple
 function observe(trajs)
     _trajs = trajs |> collect
     all_keys = union([keys(traj) for traj in _trajs]...)
     get_values(key) = [get(traj, key, missing) for traj in _trajs]
     all_values = all_keys |> Map(get_values)
-    return zip(all_keys, all_values) |> Dict
+    return (; zip(all_keys, all_values)...)  # NamedTuple
 end
 # initial condition
-function generate_initial_values()
-    x1 = [1, 2, 3]
-    x2 = [3, 2, 1]
-    return Dict(:sys1 => x1, :sys2 => x2)
-end
+LazyFym.initial_condition(sys::Sys1) = [1, 2, 3]
+LazyFym.initial_condition(sys::Sys2) = [3, 2, 1]
 
 
 function test()
@@ -96,24 +94,21 @@ function test()
     Δt = 0.01
     ts = t0:Δt:tf
     ts_reverse = t0:-Δt:-tf
-    # initial condition
-    x0 = generate_initial_values()
+    # extend `LazyFym.initial_condition` will automatically construct a NamedTuple; not mandatory
+    x0 = LazyFym.initial_condition(env)
     # simulator
-    trajs(x0, ts) = foldxl(|>, [
-                                Sim(env, x0, ts, ẋ, update),
-                                TakeWhile(!is_terminated),
-                               ])
+    trajs(x0, ts) = Sim(env, x0, ts, ẋ, update)
     @time trajs(x0, ts_reverse) |> observe  # reverse time test
     # reuse simulator
-    @time res = trajs(x0, ts) |> observe
+    @time res = trajs(x0, ts) |> TakeWhile(!is_terminated) |> observe
     # exact solution
     x1_exact = function(t)
         c = gain(t)
-        return exp(-env.sys1.a * c * t) * x0[:sys1]
+        return exp(-env.sys1.a * c * t) * x0.sys1
     end
-    x1_exacts = res[:t] |> Map(x1_exact) |> collect
+    x1_exacts = res.t |> Map(x1_exact) |> collect
     ϵ = 1e-5
-    @test ([norm(res[:x1][i] - x1_exacts[i])
+    @test ([norm(res.x1[i] - x1_exacts[i])
             for i in 1:length(x1_exacts)] |> maximum) < ϵ
 end
 

--- a/src/LazyFym.jl
+++ b/src/LazyFym.jl
@@ -61,7 +61,7 @@ end
 ## (internal) API
 # get names
 function system_names(env::FymEnv)
-    return [name for name in fieldnames(typeof(env)) if typeof(getfield(env, name)) <: FymSys]
+    return [name for name in fieldnames(typeof(env)) if typeof(getfield(env, name)) <: Union{FymSys, FymEnv}]
 end
 function preprocess(env::FymEnv, x0)
     sys_names = system_names(env)
@@ -93,6 +93,12 @@ function process(_x, sys_index_dict, sys_size_dict)
     )
     x = zip(sys_names, sys_values) |> Dict
     return x
+end
+# initial condition
+function initial_condition(env::Union{FymSys, FymEnv})
+    names = LazyFym.system_names(env)
+    values = names |> Map(name -> initial_condition(getfield(env, name)))
+    return zip(names, values) |> Dict
 end
 
 ## Simulator

--- a/src/LazyFym.jl
+++ b/src/LazyFym.jl
@@ -2,19 +2,16 @@ module LazyFym
 
 using Transducers
 
-export FymSys
 export FymEnv
 
 export ∫
 # export euler, rk4  # exporting them is deprecated
-
 # export update, ẋ  # exporting them is deprecated
 
 export Sim
 
 
 ## Types
-abstract type FymSys end
 abstract type FymEnv end
 
 ## numerical integration
@@ -61,7 +58,7 @@ end
 ## (internal) API
 # get names
 function system_names(env::FymEnv)
-    return [name for name in fieldnames(typeof(env)) if typeof(getfield(env, name)) <: Union{FymSys, FymEnv}]
+    return [name for name in fieldnames(typeof(env)) if typeof(getfield(env, name)) <: FymEnv]
 end
 function preprocess(env::FymEnv, x0)
     sys_names = system_names(env)
@@ -95,7 +92,7 @@ function process(_x, sys_index_dict, sys_size_dict)
     return x
 end
 # initial condition
-function initial_condition(env::Union{FymSys, FymEnv})
+function initial_condition(env::FymEnv)
     names = LazyFym.system_names(env)
     values = names |> Map(name -> initial_condition(getfield(env, name)))
     return zip(names, values) |> Dict

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,10 +6,10 @@ using LinearAlgebra
 
 
 # systems
-struct Sys1 <: FymSys
+struct Sys1 <: FymEnv
     a
 end
-struct Sys2 <: FymSys
+struct Sys2 <: FymEnv
     b
 end
 # environments

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,18 +19,19 @@ struct Env <: FymEnv
 end
 # dynamics
 function ẋ(env::Env, x, t; c=1)
-    x1 = x[:sys1]
-    x2 = x[:sys2]
+    x1 = x.sys1  # x will be given as NamedTuple
+    x2 = x.sys2
     ẋ1 = -(env.sys1.a * c) * x1
     ẋ2 = -(env.sys2.b * c) * x2
-    return zip([:sys1, :sys2], [ẋ1, ẋ2]) |> Dict
+    return (; zip([:sys1, :sys2], [ẋ1, ẋ2])...)  # NamedTuple; Dict will also work
 end
 # update rule within each time step
 function update(env::Env, ẋ, x, t, Δt)
-    datum = Dict(:x1 => x[:sys1], :x2 => x[:sys2], :t => t)
+    _datum = Dict(:x1 => x.sys1, :x2 => x.sys2, :t => t)
     c = gain(t)
     x_next = ∫(env, ẋ, x, t, Δt; c=c)  # default method: RK4
-    # datum[:x_next] = x  # if necessary
+    _datum[:x_next] = x_next  # if necessary
+    datum = (; zip(keys(_datum), values(_datum))...)  # to make it immutable; not necessary
     return datum, x_next
 end
 function gain(t)
@@ -38,22 +39,19 @@ function gain(t)
 end
 # terminal condition
 function is_terminated(datum)
-    return datum[:t] > 50
+    return norm(datum.x1) < 1e-6
 end
-# trajs -> dict
+# trajs -> NamedTuple
 function observe(trajs)
     _trajs = trajs |> collect
     all_keys = union([keys(traj) for traj in _trajs]...)
     get_values(key) = [get(traj, key, missing) for traj in _trajs]
     all_values = all_keys |> Map(get_values)
-    return zip(all_keys, all_values) |> Dict
+    return (; zip(all_keys, all_values)...)  # NamedTuple
 end
 # initial condition
-function generate_initial_values()
-    x1 = [1, 2, 3]
-    x2 = [3, 2, 1]
-    return Dict(:sys1 => x1, :sys2 => x2)
-end
+LazyFym.initial_condition(sys::Sys1) = [1, 2, 3]
+LazyFym.initial_condition(sys::Sys2) = [3, 2, 1]
 
 
 function test()
@@ -66,24 +64,21 @@ function test()
     Δt = 0.01
     ts = t0:Δt:tf
     ts_reverse = t0:-Δt:-tf
-    # initial condition
-    x0 = generate_initial_values()
+    # extend `LazyFym.initial_condition` will automatically construct a NamedTuple; not mandatory
+    x0 = LazyFym.initial_condition(env)
     # simulator
-    trajs(x0, ts) = foldxl(|>, [
-                                Sim(env, x0, ts, ẋ, update),
-                                TakeWhile(!is_terminated),
-                               ])
+    trajs(x0, ts) = Sim(env, x0, ts, ẋ, update)
     @time trajs(x0, ts_reverse) |> observe  # reverse time test
     # reuse simulator
-    @time res = trajs(x0, ts) |> observe
+    @time res = trajs(x0, ts) |> TakeWhile(!is_terminated) |> observe
     # exact solution
     x1_exact = function(t)
         c = gain(t)
-        return exp(-env.sys1.a * c * t) * x0[:sys1]
+        return exp(-env.sys1.a * c * t) * x0.sys1
     end
-    x1_exacts = res[:t] |> Map(x1_exact) |> collect
+    x1_exacts = res.t |> Map(x1_exact) |> collect
     ϵ = 1e-5
-    @test ([norm(res[:x1][i] - x1_exacts[i])
+    @test ([norm(res.x1[i] - x1_exacts[i])
             for i in 1:length(x1_exacts)] |> maximum) < ϵ
 end
 

--- a/test/tmp.jl
+++ b/test/tmp.jl
@@ -1,0 +1,25 @@
+using LazyFym
+using Transducers
+
+struct MyT <: FymEnv
+    syss
+end
+
+struct Syss <: FymEnv
+    sys1
+    sys2
+end
+
+struct Sys1 <: FymSys
+    a
+end
+
+LazyFym.initial_condition(sys::Sys1) = [1, 2, 3]
+syss = Syss(Sys1(1), Sys1(2))
+myt = MyT(syss)
+x0 = LazyFym.initial_condition(myt)
+LazyFym.size(myt, x0)
+LazyFym.index(myt, x0)
+
+@show initial_condition(syss)
+res = initial_condition(myt)

--- a/test/tmp.jl
+++ b/test/tmp.jl
@@ -10,7 +10,7 @@ struct Syss <: FymEnv
     sys2
 end
 
-struct Sys1 <: FymSys
+struct Sys1 <: FymEnv
     a
 end
 


### PR DESCRIPTION
# Changes
## Interface
### Important
- Type `FymSys` has been deprecated. In fact, there is no difference between `FymSys` and `FymEnv`.
- Default setting: Data are regarded as `NamedTuple`.
    - This makes it easy to access data, for example, both `nt.a` and `nt[a]` can be used to access a data `nt.a` for given `NamedTuple` data `nt`.
    - Also, data internally processed as `NamedTuple`, which is immutable. This improves the stability of the whole simulation.
### For convenience
- `LazyFym.initial_condition(env)` will automatically construct an appropriate initial condition based on user-defined `LazyFym.initial_condition(subenv)` where `subenv` denotes a sub-environment of `env`.