### PR TITLE
Improve performance by telling information; add simulation examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,13 @@ authors = ["JinraeKim <kjl950403@gmail.com> and contributors"]
 version = "0.2.0"
 
 [deps]
+BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
-julia = "1.5"
 Transducers = "0.4"
+julia = "1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ using Test
 using Transducers
 
 using LinearAlgebra
-using Plots
+# using Plots
 
 
 # sub-envs

--- a/README.md
+++ b/README.md
@@ -18,9 +18,16 @@ LazyFym supports **nested environments**.
 In addition,
 LazyFym does not restrict the forms of your custom environments
 and thus provides a general-purpose interface.
-### Parallelism
+You can take either eager or lazy data postprocessing with LazyFym.
+Since LazyFym automatically calculate the information of environments (including size, flatten_length, etc.),
+you should consider extend `LazyFym` functions for your custom environments such as `LazyFym.size`
+to improve the simulation speed.
+### Parallelism (Todo)
 (It is expected that parallel simulation is easy with this package.
 Detailed explanation will be given after testing some examples.)
+### Performance improvement for simulations with long time span (Todo)
+(I'm trying to apply some ideas, e.g., `PartitionedSim`,
+but it seems not fast as I expected.)
 
 ## Interface
 LazyFym provides a Type `FymEnv`.
@@ -30,105 +37,9 @@ probably consisting of other `FymEnv`s as sub-environments (sub-systems).
 Examples including simulation with a custom environment
 can be found in directory `test`.
 Here is a basic example:
-```julia
-using LazyFym
-using Test
-using Transducers
-
-using LinearAlgebra
-# using Plots
-
-
-# sub-envs
-struct Env1 <: FymEnv
-    a
-end
-struct Env2 <: FymEnv
-    b
-end
-struct EnvBig <: FymEnv
-    env1::Env1
-    env2::Env2
-end
-# environments
-struct Env <: FymEnv
-    env1::Env1
-    envbig::EnvBig
-end
-# dynamics
-function ẋ(env::Env, x, t; c=1)
-    x1 = x.env1  # x will be given as NamedTuple
-    xbig1 = x.envbig.env1
-    xbig2 = x.envbig.env2
-    ẋ1 = -(env.env1.a * c) * x1
-    ẋbig1 = -(env.envbig.env1.a * c) * xbig1
-    ẋbig2 = -(env.envbig.env2.b * c) * xbig2
-    return (; env1 = ẋ1, envbig = (; env1 = ẋbig1, env2 = ẋbig2))
-end
-# update rule within each time step
-function update(env::Env, ẋ, x, t, Δt)
-    _datum = Dict()
-    _datum[:t] = t
-    _datum[:x1] = x.env1
-    _datum[:xbig1] = x.envbig.env1
-    _datum[:xbig2] = x.envbig.env2
-    c = gain(t)
-    x_next = ∫(env, ẋ, x, t, Δt; c=c)  # default method: RK4
-    # Recording data after update is someetimes required
-    # e.g., integrated reward in integral reinforcement learning
-    _datum[:x1_next] = x_next.env1
-    _datum[:xbig1_next] = x_next.envbig.env1
-    _datum[:xbig2_next] = x_next.envbig.env2
-    datum = (; zip(keys(_datum), values(_datum))...)  # to make it immutable; not necessary
-    return datum, x_next
-end
-function gain(t)
-    return 1  # for test
-end
-# terminal condition
-function is_terminated(datum)
-    return norm(datum.x1) < 1e-6
-end
-# initial condition
-LazyFym.initial_condition(env::Env1) = [1, 2, 3]
-LazyFym.initial_condition(env::Env2) = [3, 2, 1]
-
-
-function custom_env()
-    env1 = Env1(2.0)
-    envbig1 = Env1(3.0)
-    envbig2 = Env2(1.0)
-    envbig = EnvBig(envbig1, envbig2)
-    env = Env(env1, envbig)
-    # time
-    t0 = 0.0
-    tf = 100.0
-    Δt = 0.01
-    ts = t0:Δt:tf
-    ts_reverse = t0:-Δt:-tf
-    # extend `LazyFym.initial_condition` will automatically construct a NamedTuple; not mandatory
-    x0 = LazyFym.initial_condition(env)
-    # simulator
-    trajs(x0, ts) = Sim(env, x0, ts, ẋ, update)
-    # trajs(x0, ts) = Sim(env, x0, ts, LazyFym.ẋ, LazyFym.update)  # for test
-    @time trajs(x0, ts) |> evaluate  # reuse test
-    @time data = trajs(x0, ts) |> TakeWhile(!is_terminated) |> evaluate
-    # exact solution
-    x1_exact = function(t)
-        c = gain(t)
-        return exp(-env.env1.a * c * t) * x0.env1
-    end
-    x1_exacts = data.t |> Map(x1_exact) |> collect
-    ϵ = 1e-5
-    @test ([norm(data.x1[i] - x1_exacts[i]) for i in 1:length(x1_exacts)] |> maximum) < ϵ
-    # plot(data.t, sequentialise(data.x1))
-    # return data  # for debug
-end
-
-custom_env()
-# data = custom_env()  # for debug
+```
 ```
 ## Todo
 - [x] Nested environments (like `fym` and `FymEnvs`)
-- [ ] Performance optimisation (supporting nested env. makes it slow)
+- [x] Performance improvement (supporting nested env. makes it slow -> can be improved by telling LazyFym the information of your custom environments)
 - [ ] Add an example of parallel simulation

--- a/README.md
+++ b/README.md
@@ -38,6 +38,119 @@ Examples including simulation with a custom environment
 can be found in directory `test`.
 Here is a basic example:
 ```
+using LazyFym
+using Test
+using Transducers
+
+using LinearAlgebra
+
+
+# sub-envs
+struct Env1 <: FymEnv
+    a
+end
+struct Env2 <: FymEnv
+    b
+end
+struct EnvBig <: FymEnv
+    env1::Env1
+    env2::Env2
+end
+# environments
+struct Env <: FymEnv
+    env1::Env1
+    envbig::EnvBig
+end
+# dynamics
+function ẋ(env::Env, x, t; c=1)
+    x1 = x.env1  # x will be given as NamedTuple
+    xbig1 = x.envbig.env1
+    xbig2 = x.envbig.env2
+    ẋ1 = -(env.env1.a * c) * x1
+    ẋbig1 = -(env.envbig.env1.a * c) * xbig1
+    ẋbig2 = -(env.envbig.env2.b * c) * xbig2
+    return (; env1 = ẋ1, envbig = (; env1 = ẋbig1, env2 = ẋbig2))
+end
+# (eager data postprocessing) update rule within each time step
+# To improve simulator speed, you should consider lazy data postprocessing using `LazyFym.update`.
+function update(env::Env, ẋ, x, t, Δt)
+    _datum = Dict()
+    _datum[:x] = x
+    _datum[:t] = t
+    _datum[:x1] = x.env1
+    _datum[:xbig1] = x.envbig.env1
+    _datum[:xbig2] = x.envbig.env2
+    c = gain(t)
+    x_next = ∫(env, ẋ, x, t, Δt; c=c)  # default method: RK4
+    # Recording data after update is someetimes required
+    # e.g., integrated reward in integral reinforcement learning
+    _datum[:x_next] = x_next
+    _datum[:x1_next] = x_next.env1
+    _datum[:xbig1_next] = x_next.envbig.env1
+    _datum[:xbig2_next] = x_next.envbig.env2
+    datum = (; zip(keys(_datum), values(_datum))...)  # to make it immutable; not necessary
+    return datum, x_next
+end
+function postprocess(datum_raw)
+    _datum = Dict(:t => datum_raw.t, :x1 => datum_raw.x.env1)
+    datum = (; zip(keys(_datum), values(_datum))...)
+    return datum
+end
+function gain(t)
+    return 1  # for test
+end
+# terminal condition
+function terminal_condition(datum)
+    return norm(datum.x.env1) < 1e-6
+end
+function terminal_condition_readable(datum)
+    return norm(datum.x1) < 1e-6
+end
+# initial condition
+LazyFym.initial_condition(env::Env1) = [1, 2, 3]
+LazyFym.initial_condition(env::Env2) = [3, 2, 1]
+
+
+## lazy postprocessing
+function default_update()
+    println("Simulation with custom update (lazy postprocessing)")
+    env1 = Env1(2.0)
+    envbig1 = Env1(3.0)
+    envbig2 = Env2(1.0)
+    envbig = EnvBig(envbig1, envbig2)
+    env = Env(env1, envbig)
+    # time
+    t0 = 0.0
+    tf = 100.0
+    Δt = 0.01
+    ts = t0:Δt:tf
+    # extend `LazyFym.initial_condition` will automatically construct a NamedTuple; not mandatory
+    x0 = LazyFym.initial_condition(env)
+    # simulator (default)
+    trajs(x0, ts) = Sim(env, x0, ts, ẋ)  # `update` is loaded from `LazyFym`
+    # (example) simulation with terminal condition
+    @time _ = trajs(x0, ts) |> TakeWhile(!terminal_condition) |> Map(postprocess) |> evaluate
+    @time data_ = trajs(x0, ts) |> Map(postprocess) |> TakeWhile(!terminal_condition_readable) |> evaluate
+    # (example) simulation with given time span
+    @time data = trajs(x0, ts) |> Map(postprocess) |> evaluate
+    # (tool) `PartitionedSim` for very long simulation (to use this, you must add `x_next` to datum in your custom `update` function)
+    # TODO: `PartitionedSim` is quite slow although it is introduced for long simulation
+    @time _data = LazyFym.PartitionedSim(trajs, x0, ts; horizon=1000) |> Map(postprocess) |> TakeWhile(!terminal_condition_readable) |> evaluate
+    _trajs(x0, ts) = trajs(x0, ts) |> TakeWhile(!terminal_condition)
+    @time _ = LazyFym.PartitionedSim(_trajs, x0, ts; horizon=1000) |> Map(postprocess) |> evaluate
+    @test data_ == _data  # test `PartitionedSim`
+    # (test) compare simulation result with the exact solution (linear system)
+    x1_exact = function(t)
+        c = gain(t)
+        return exp(-env.env1.a * c * t) * x0.env1
+    end
+    x1_exacts = data.t |> Map(x1_exact) |> collect
+    ϵ = 1e-6
+    @test ([norm(data.x1[i] - x1_exacts[i]) for i in 1:length(x1_exacts)] |> maximum) < ϵ
+    return data_, data, _data  # for test
+end
+
+default_update()
 ```
 ## Todo
 - [x] Nested environments (like `fym` and `FymEnvs`)

--- a/src/LazyFym.jl
+++ b/src/LazyFym.jl
@@ -4,6 +4,7 @@ using Transducers
 
 # Types
 export FymEnv
+export FymSim
 # convenient APIs
 export ∫
 export Sim
@@ -14,6 +15,7 @@ export evaluate, sequentialise
 
 
 ## Types
+# environments
 abstract type FymEnv end
 
 ## Numerical integration
@@ -51,8 +53,35 @@ Step(env, x0, t0, ẋ, update) = ScanEmit((x0, t0)) do (x, t), t_next
     datum, x_next = update(env, ẋ, x, t, Δt)
     return datum, (x_next, t_next)
 end
-# simulation
+# simulation (better for short simulation time)
 Sim(env::FymEnv, x0, ts, ẋ, update) = foldxl(|>, [ts, Drop(1), Step(env, x0, ts[1], ẋ, update)])
+Sim(env::FymEnv, x0, ts, ẋ) = Sim(env::FymEnv, x0, ts, ẋ, update)  # default data structure
+Sim(env::FymEnv, x0, ts) = Sim(env::FymEnv, x0, ts, ẋ, update)  # for test
+# partitioned simulation (better for long simulation time)
+function PartitionedSim(trajs, x0, ts, horizon=1000)
+    ts_length = ts |> collect |> length
+    if ts_length < horizon
+        error("Partition horizon should be less than the number of time instants")
+    end
+    # ex) trajs(x0, ts) = Sim(env, x0, ts, ẋ, update) |> TakeWhile(!is_terminated)
+    split_sim(x0, ts0) = ScanEmit((x0, ts0)) do (x, ts), ts_next
+        data = trajs(x, ts) |> evaluate
+        x_next = data.x_next[end]
+        return data, (x_next, ts_next)
+    end
+    ts_partitioned = ts |> Partition(horizon, step=horizon-1, flush=true) |> Map(copy)
+    ts_partitioned_appended = [ts_partitioned..., missing]
+    _data = ts_partitioned_appended |> Drop(1) |> split_sim(x0, ts[1:horizon]) |> collect
+    data = merge_trajs(_data)
+    return data
+end
+function merge_trajs(trajs_partitioned)
+    _trajs_partitioned = trajs_partitioned |> collect
+    all_keys = union([keys(traj) for traj in _trajs_partitioned]...)
+    get_values(key) = vcat([get(traj, key, missing) for traj in _trajs_partitioned]...)
+    all_values = all_keys |> Map(get_values)
+    return (; zip(all_keys, all_values)...)
+end
 
 ## Convenient tools
 # all-zero dynamics (for test)
@@ -67,8 +96,10 @@ function ẋ(env::FymEnv, x, t)
 end
 # default update (for test)
 function update(env::FymEnv, ẋ, x, t, Δt)  # provided
-    datum = Dict(:state => x, :t => t)
+    _datum = Dict(:x => x, :t => t)
     x_next = ∫(env, ẋ, x, t, Δt)
+    _datum[:x_next] = x_next
+    datum = (; zip(keys(_datum), values(_datum))...)
     return datum, x_next
 end
 # automatic completion of initial condition
@@ -77,7 +108,7 @@ function initial_condition(env::FymEnv)
     values = env_names |> Map(name -> initial_condition(getfield(env, name)))
     return (; zip(env_names, values)...)  # NamedTuple
 end
-# trajs -> NamedTuple
+# trajs -> NamedTuple (may take a lot of time for long time span)
 function evaluate(trajs)
     _trajs = trajs |> collect
     all_keys = union([keys(traj) for traj in _trajs]...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,7 +70,20 @@ end
 # initial condition
 LazyFym.initial_condition(env::Env1) = [1, 2, 3]
 LazyFym.initial_condition(env::Env2) = [3, 2, 1]
-LazyFym.size(env::Env1) = println("hello")
+# `LazyFym` will automatically calculate the state of each environment (system).
+# To enhance the simulation performance, you should consider "telling the information to LazyFym" as follows.
+_env1 = Env1(1.0)  # aux
+_envbig1 = Env1(1.0)  # aux
+_envbig2 = Env2(1.0)  # aux
+_envbig = EnvBig(_envbig1, _envbig2)  # aux
+_env = Env(_env1, _envbig)  # aux
+_x0 = LazyFym.initial_condition(_env)  # aux
+_size = LazyFym.size(_env, _x0)
+_flatten_length = LazyFym.flatten_length(_env, _x0)
+_index = LazyFym.index(_env, _x0, 1:_flatten_length)
+LazyFym.size(_env::Env, x) = _size
+LazyFym.flatten_length(_env::Env, x) = _flatten_length
+LazyFym.index(_env::Env, x, _range) = _index
 
 
 ## lazy postprocessing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using Test
 using Transducers
 
 using LinearAlgebra
-# using Plots
 
 
 # sub-envs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using Transducers
 
 using LinearAlgebra
-using Plots
+# using Plots
 
 
 # sub-envs


### PR DESCRIPTION
# Changes
## Performance improvement
- You can highly improve the simulation speed by telling `LazyFym` the information of your custom environments, for example, `LazyFym.size` and `LazyFym.index`.


# Notes
## `PartitionedSim` is added but it seems not faster.